### PR TITLE
Fix/missing transfer tokens export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@nahmii/sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The `@nahmii/sdk` package is an SDK to interact with Nahmii 2.0.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/index",
+  "types": "dist/index",
   "files": [
     "dist/**/*.js",
     "dist/**/*.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './l2-to-L1-message-relaying'
-export * from './string-format'
 export * from './rlp'
+export * from './string-format'
+export * from './transfer-tokens'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
+    "outDir": "./dist"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
**Purpose**
The `transfer-tokens` functions were not exposed by the SDK.

**Changes**
- Export the `transfer-tokens` file in the SDKs entry point.
- Update build configuration files to properly expose all the functions within the SDK.