### PR TITLE
Rename default gas constant

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_GAS_L1 = 330_000
+export const DEFAULT_ETH_GAS_L1 = 330_000
 export const DEFAULT_GAS_L2 = 1_300_000

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_ETH_GAS_L1 = 330_000
 export const DEFAULT_GAS_L2 = 1_300_000
+export const ETH_GAS_LIMIT_L1 = 250_000

--- a/src/transfer-tokens.ts
+++ b/src/transfer-tokens.ts
@@ -3,7 +3,7 @@ import { predeploys } from './predeploys'
 import L1StandardBridgeABI from './contract-metadata/L1StandardBridgeABI.json'
 import L2StandardBridgeABI from './contract-metadata/L2StandardBridgeABI.json'
 import { relayL2ToL1Messages } from './l2-to-L1-message-relaying'
-import { DEFAULT_GAS_L1, DEFAULT_GAS_L2 } from './constants'
+import { ETH_GAS_LIMIT_L1, DEFAULT_GAS_L2 } from './constants'
 export { relayL2ToL1Messages }
 
 /**
@@ -25,7 +25,7 @@ export const depositETH = async (
   const contract = new ethers.Contract(bridgeAddress, L1StandardBridgeInterface, l1Provider)
   const transactionResponse = await contract.connect(signer).depositETH(DEFAULT_GAS_L2, '0xFFFF', {
     value: depositAmount,
-    gasLimit: DEFAULT_GAS_L1,
+    gasLimit: ETH_GAS_LIMIT_L1,
   })
 
   return transactionResponse


### PR DESCRIPTION
**Purpose**
Bring the naming scheme of one of the constants more in line with what it really does. Decrease the gas limit, but still within a safe range, to reduce the minimum balance required by a user.

**Changes**
- Rename constant.
- Reduce gas limit.

**Check list**
- [x] Code runs without regressions even though new code is incomplete
- [ ] Code reviewer has been explicitly notified outside automatic notification channels
