### PR TITLE
Feature/single sided transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nahmii/sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The `@nahmii/sdk` package is an SDK to interact with Nahmii 2.0.",
   "main": "dist/index",
   "types": "dist/index",

--- a/src/token-transfers.ts
+++ b/src/token-transfers.ts
@@ -11,8 +11,10 @@ import { ERC20Transfer, ERC20TransfersOptions } from './types'
  * @param {ethers.providers.BlockTag} [fromBlock] Tag of from block
  * @param {ethers.providers.BlockTag} [toBlock] Tag of to block
  * @param {ERC20TransfersOptions} [options] Options
- * @param {boolean} [options.transactionResponse] If true include the transaction response
- * @param {boolean} [options.transactionReceipt] If true include the transaction receipt
+ * @param {boolean} [options.transactionResponse] If true then include the transaction response
+ * @param {boolean} [options.transactionReceipt] If true then include the transaction receipt
+ * @param {boolean} [options.isSender] If false then don't include transfers with accountAddress as sender
+ * @param {boolean} [options.isRecipient] If false then don't include transfers with accountAddress as recipient
  * @returns Returns the account's transfers of ETH
  */
 export const transfersOfETH = async (
@@ -34,8 +36,10 @@ export const transfersOfETH = async (
  * @param {ethers.providers.BlockTag} [fromBlock] Tag of from block
  * @param {ethers.providers.BlockTag} [toBlock] Tag of to block
  * @param {ERC20TransfersOptions} [options] Options
- * @param {boolean} [options.transactionResponse] If true include the transaction response
- * @param {boolean} [options.transactionReceipt] If true include the transaction receipt
+ * @param {boolean} [options.transactionResponse] If true then include the transaction response
+ * @param {boolean} [options.transactionReceipt] If true then include the transaction receipt
+ * @param {boolean} [options.isSender] If false then don't include transfers with accountAddress as sender
+ * @param {boolean} [options.isRecipient] If false then don't include transfers with accountAddress as recipient
  * @returns Returns the account's transfers of the ERC20 tokens
  */
 export const transfersOfERC20 = async (
@@ -50,8 +54,12 @@ export const transfersOfERC20 = async (
   const contract = new ethers.Contract(contractAddress, L2StandardERC20Interface, l2Provider)
 
   const [sends, receives] = await Promise.all([
-    contract.queryFilter(contract.filters.Transfer(accountAddress, undefined), fromBlock, toBlock),
-    contract.queryFilter(contract.filters.Transfer(undefined, accountAddress), fromBlock, toBlock),
+    !options || options.isSender !== false
+      ? contract.queryFilter(contract.filters.Transfer(accountAddress, undefined), fromBlock, toBlock)
+      : [],
+    !options || options.isRecipient !== false
+      ? contract.queryFilter(contract.filters.Transfer(undefined, accountAddress), fromBlock, toBlock)
+      : [],
   ])
 
   return Promise.all(

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,4 +22,6 @@ export interface ERC20Transfer {
 export interface ERC20TransfersOptions {
   transactionResponse?: boolean
   transactionReceipt?: boolean
+  isSender?: boolean
+  isRecipient?: boolean
 }


### PR DESCRIPTION
**Purpose**
<!-- Write here the purpose of the code change in terms of the benefit intended. -->
Enable the retrieval of ETH and ERC20 transfers where the provided account is not sender or not recipient, in addition to the existing support for any of the two roles on transfers.

**Changes**
<!-- Short list of code changes in this -->
* Augment interface `ERC20TransferOptions` by boolean type properties `isSender` and `isRecipient`
* Limit query of `TransferEvent` values of the above options properties

**Check list**
<!-- Ensure that the following tasks have been completed before code review is requested. -->
- [ ] Code runs without regressions even though new code is incomplete
- [x] Automatic tests have been written, they work, and code coverage has been maintained.
- [ ] Code has been submitted to build server and build succeeds
- [x] Code reviewer has been explicitly notified outside automatic notification channels
