### PR TITLE
ERC20 transfers timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nahmii/sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The `@nahmii/sdk` package is an SDK to interact with Nahmii 2.0.",
   "main": "dist/index",
   "types": "dist/index",

--- a/src/token-balances.ts
+++ b/src/token-balances.ts
@@ -35,10 +35,6 @@ export const balanceOfERC20 = async (
 ): Promise<BigNumber> => {
   const L2StandardERC20Interface = new ethers.utils.Interface(L2StandardERC20ABI)
   const contract = new ethers.Contract(contractAddress, L2StandardERC20Interface, l2Provider)
-
-  if (block) {
-    return contract.balanceOf(accountAddress, { blockTag: block })
-  } else {
-    return contract.balanceOf(accountAddress)
-  }
+  const overrides = block ? { blockTag: block } : null
+  return contract.balanceOf(accountAddress, overrides)
 }

--- a/src/token-balances.ts
+++ b/src/token-balances.ts
@@ -35,6 +35,10 @@ export const balanceOfERC20 = async (
 ): Promise<BigNumber> => {
   const L2StandardERC20Interface = new ethers.utils.Interface(L2StandardERC20ABI)
   const contract = new ethers.Contract(contractAddress, L2StandardERC20Interface, l2Provider)
-  const overrides = block ? { blockTag: block } : undefined
-  return contract.balanceOf(accountAddress, overrides)
+
+  if (block) {
+    return contract.balanceOf(accountAddress, { blockTag: block })
+  } else {
+    return contract.balanceOf(accountAddress)
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Decoded {
 
 export interface ERC20Transfer {
   contractAddress: string
+  timestamp: number
   sender: string
   recipient: string
   amount: number

--- a/test/token-balances.spec.ts
+++ b/test/token-balances.spec.ts
@@ -52,7 +52,7 @@ describe('token-balances', () => {
         const balance = await tokenBalances.balanceOfETH(accountAddress, l2Provider)
 
         expect(balance).to.equal(expectedBalance)
-        expect(balanceOf).to.have.been.calledWithExactly(accountAddress, undefined)
+        expect(balanceOf).to.have.been.calledWithExactly(accountAddress)
       })
     })
   })
@@ -72,7 +72,7 @@ describe('token-balances', () => {
         const balance = await tokenBalances.balanceOfERC20(contractAddress, accountAddress, l2Provider)
 
         expect(balance).to.equal(expectedBalance)
-        expect(balanceOf).to.have.been.calledWithExactly(accountAddress, undefined)
+        expect(balanceOf).to.have.been.calledWithExactly(accountAddress)
       })
     })
   })

--- a/test/token-balances.spec.ts
+++ b/test/token-balances.spec.ts
@@ -52,7 +52,7 @@ describe('token-balances', () => {
         const balance = await tokenBalances.balanceOfETH(accountAddress, l2Provider)
 
         expect(balance).to.equal(expectedBalance)
-        expect(balanceOf).to.have.been.calledWithExactly(accountAddress)
+        expect(balanceOf).to.have.been.calledWithExactly(accountAddress, null)
       })
     })
   })
@@ -72,7 +72,7 @@ describe('token-balances', () => {
         const balance = await tokenBalances.balanceOfERC20(contractAddress, accountAddress, l2Provider)
 
         expect(balance).to.equal(expectedBalance)
-        expect(balanceOf).to.have.been.calledWithExactly(accountAddress)
+        expect(balanceOf).to.have.been.calledWithExactly(accountAddress, null)
       })
     })
   })


### PR DESCRIPTION
**Purpose**
<!-- Write here the purpose of the code change in terms of the benefit intended. -->
The purpose of this PR is to enable a timestamp property on returned instances of `ERC20Transfer`.

**Issues**
<!-- List issues addesses by the code change. Prefix issue with "Closes" if the issue is resolved. e.g: "Closes #15" -->
<!-- That will automatically close the issue when this PR has been merged. -->

**Changes**
<!-- Short list of code changes in this -->
* Augment the `ERC20Transfer` type with timestamp number property.
* Get the timestamp associated with each ERC20 and ETH transfer.
* Update call to `ERC20#transferOf()` so that undefined overrides is not passed explicitly.

**Check list**
<!-- Ensure that the following tasks have been completed before code review is requested. -->
- [x] Code runs without regressions even though new code is incomplete
- [x] Automatic tests have been written, they work, and code coverage has been maintained.
- [ ] Code has been submitted to build server and build succeeds
- [x] Code reviewer has been explicitly notified outside automatic notification channels
