### PR TITLE
Add functions to deposit ETH and ERC20 to account other than sender

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nahmii/sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "The `@nahmii/sdk` package is an SDK to interact with Nahmii 2.0.",
   "main": "dist/index",
   "types": "dist/index",

--- a/src/bridge-tokens.ts
+++ b/src/bridge-tokens.ts
@@ -10,7 +10,7 @@ export { relayL2ToL1Messages }
  * Deposit Ether.
  *
  * @param bridgeAddress L1 bridge address.
- * @param depositAmount The amount to deposit in wei.
+ * @param depositAmount Amount to deposit in wei.
  * @param l1Provider L1 provider.
  * @param signer L1 transaction signer.
  * @returns Returns the transaction response containing metadata for the ETH deposit transaction.
@@ -23,12 +23,10 @@ export const depositETH = async (
 ): Promise<ethers.providers.TransactionResponse> => {
   const L1StandardBridgeInterface = new ethers.utils.Interface(L1StandardBridgeABI)
   const contract = new ethers.Contract(bridgeAddress, L1StandardBridgeInterface, l1Provider)
-  const transactionResponse = await contract.connect(signer).depositETH(DEFAULT_GAS_L2, '0xFFFF', {
+  return contract.connect(signer).depositETH(DEFAULT_GAS_L2, '0xFFFF', {
     value: depositAmount,
     gasLimit: ETH_GAS_LIMIT_L1,
   })
-
-  return transactionResponse
 }
 
 /**
@@ -37,7 +35,7 @@ export const depositETH = async (
  * @param l1TokenAddress L1 address of the token to deposit.
  * @param l2TokenAddress L2 address of the mapped equivalent of the L1 token.
  * @param bridgeAddress L1 bridge address.
- * @param depositAmount The amount to deposit in wei.
+ * @param depositAmount Amount to deposit in wei.
  * @param l1Provider L1 provider.
  * @param signer L1 transaction signer.
  * @returns Returns the transaction response containing metadata for the ETH deposit transaction.
@@ -52,11 +50,60 @@ export const depositERC20 = async (
 ): Promise<ethers.providers.TransactionResponse> => {
   const L1StandardBridgeInterface = new ethers.utils.Interface(L1StandardBridgeABI)
   const contract = new ethers.Contract(bridgeAddress, L1StandardBridgeInterface, l1Provider)
-  const transactionResponse = await contract
-    .connect(signer)
-    .depositERC20(l1TokenAddress, l2TokenAddress, depositAmount, DEFAULT_GAS_L2, '0x')
+  return contract.connect(signer).depositERC20(l1TokenAddress, l2TokenAddress, depositAmount, DEFAULT_GAS_L2, '0x')
+}
 
-  return transactionResponse
+/**
+ * Deposit ERC20 token to target account. The L1 token requires a mapped L2 token to be deployed.
+ *
+ * @param bridgeAddress L1 bridge address.
+ * @param accountAddress Address of the target account on L2.
+ * @param depositAmount Amount to deposit in wei.
+ * @param l1Provider L1 provider.
+ * @param signer L1 transaction signer.
+ * @returns Returns the transaction response containing metadata for the ETH deposit transaction.
+ */
+export const depositETHTo = async (
+  bridgeAddress: string,
+  accountAddress: string,
+  depositAmount: BigNumber,
+  l1Provider: ethers.providers.JsonRpcProvider,
+  signer: ethers.Signer
+): Promise<ethers.providers.TransactionResponse> => {
+  const L1StandardBridgeInterface = new ethers.utils.Interface(L1StandardBridgeABI)
+  const contract = new ethers.Contract(bridgeAddress, L1StandardBridgeInterface, l1Provider)
+  return contract.connect(signer).depositETHTo(accountAddress, DEFAULT_GAS_L2, '0x', {
+    value: depositAmount,
+    gasLimit: ETH_GAS_LIMIT_L1,
+  })
+}
+
+/**
+ * Deposit ERC20 token to target account. The L1 token requires a mapped L2 token to be deployed.
+ *
+ * @param l1TokenAddress L1 address of the token to deposit.
+ * @param l2TokenAddress L2 address of the mapped equivalent of the L1 token.
+ * @param bridgeAddress L1 bridge address.
+ * @param accountAddress Address of the target account on L2.
+ * @param depositAmount Amount to deposit in wei.
+ * @param l1Provider L1 provider.
+ * @param signer L1 transaction signer.
+ * @returns Returns the transaction response containing metadata for the ETH deposit transaction.
+ */
+export const depositERC20To = async (
+  l1TokenAddress: string,
+  l2TokenAddress: string,
+  bridgeAddress: string,
+  accountAddress: string,
+  depositAmount: BigNumber,
+  l1Provider: ethers.providers.JsonRpcProvider,
+  signer: ethers.Signer
+): Promise<ethers.providers.TransactionResponse> => {
+  const L1StandardBridgeInterface = new ethers.utils.Interface(L1StandardBridgeABI)
+  const contract = new ethers.Contract(bridgeAddress, L1StandardBridgeInterface, l1Provider)
+  return contract
+    .connect(signer)
+    .depositERC20To(l1TokenAddress, l2TokenAddress, accountAddress, depositAmount, DEFAULT_GAS_L2, '0x')
 }
 
 /**
@@ -76,9 +123,7 @@ export const initiateWithdrawal = async (
 ): Promise<ethers.providers.TransactionResponse> => {
   const L2StandardBridgeInterface = new ethers.utils.Interface(L2StandardBridgeABI)
   const contract = new ethers.Contract(predeploys.NVM_L2StandardBridge, L2StandardBridgeInterface, l2Provider)
-  const transactionResponse = await contract.connect(signer).withdraw(l2TokenAddress, withdrawAmount, 0, '0x')
-
-  return transactionResponse
+  return contract.connect(signer).withdraw(l2TokenAddress, withdrawAmount, 0, '0x')
 }
 
 export const finalizeWithdrawal = relayL2ToL1Messages


### PR DESCRIPTION
**Purpose**
<!-- Write here the purpose of the code change in terms of the benefit intended. -->
Enable a deposit sender account to credit an alternate account on L2

**Issues**
<!-- List issues addesses by the code change. Prefix issue with "Closes" if the issue is resolved. e.g: "Closes #15" -->
<!-- That will automatically close the issue when this PR has been merged. -->

**Changes**
<!-- Short list of code changes in this -->
* Implement `depositETHTo()` and `depositERC20To()`.

**Check list**
<!-- Ensure that the following tasks have been completed before code review is requested. -->
- [ ] Code runs without regressions even though new code is incomplete
- [ ] Automatic tests have been written, they work, and code coverage has been maintained.
- [ ] Code has been submitted to build server and build succeeds
- [x] Code reviewer has been explicitly notified outside automatic notification channels
